### PR TITLE
allow platform_app to use nfc_service for NFC tile

### DIFF
--- a/prebuilts/api/28.0/private/platform_app.te
+++ b/prebuilts/api/28.0/private/platform_app.te
@@ -53,6 +53,7 @@ allow platform_app mediametrics_service:service_manager find;
 allow platform_app mediaextractor_service:service_manager find;
 allow platform_app mediacodec_service:service_manager find;
 allow platform_app mediadrmserver_service:service_manager find;
+allow platform_app nfc_service:service_manager find;
 allow platform_app persistent_data_block_service:service_manager find;
 allow platform_app radio_service:service_manager find;
 allow platform_app thermal_service:service_manager find;

--- a/private/platform_app.te
+++ b/private/platform_app.te
@@ -53,6 +53,7 @@ allow platform_app mediametrics_service:service_manager find;
 allow platform_app mediaextractor_service:service_manager find;
 allow platform_app mediacodec_service:service_manager find;
 allow platform_app mediadrmserver_service:service_manager find;
+allow platform_app nfc_service:service_manager find;
 allow platform_app persistent_data_block_service:service_manager find;
 allow platform_app radio_service:service_manager find;
 allow platform_app thermal_service:service_manager find;


### PR DESCRIPTION
This is already permitted for priv_app and even untrusted_app.

Change-Id: I02fe4411c2c9acd1b907028e5e2f019a74788133
Signed-off-by: spezi77 <spezi77@gmx.com>
Signed-off-by: xyyx <xyyx@mail.ru>